### PR TITLE
Debug screen without obstruction

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -2223,7 +2223,9 @@ local function widgetRefresh(widget)
         if page < page_min then page = page_min end
     end
     
-    drawNoTelemetry()
+    if pages[page] ~= cPageIdAction then
+      drawNoTelemetry()
+    end    
     
     -- y = 256 is the smallest for normal sized text ??? really ???, no, if there is undersling
     -- normal font is 13 pix height => 243, 256


### PR DESCRIPTION
In order for the debug screen to not overlay the [I]no telemetry[/I] message to be able to see the content when telemetry is not (yet) active.
I tested this change on my radio, now shows also all stats without overlay, when telemetry is not yet active.